### PR TITLE
Add Gradio app defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,12 @@ python upscale.py [目錄路徑] --width [目標寬度] --height [目標高度] 
 | upscale_model | 放大使用的模型 | HGSR-MHR-anime-aug_X4_320 |
 | upscale_min_size | 最小尺寸閾值 | 800 |
 
+## Gradio 介面預設值
+
+執行 `gradio_app.py` 可使用圖形介面處理圖片。若 `.env` 檔案中設置了
+`directory` 或 `output_directory` 等環境變數，這些值會自動填入對應的輸入框，
+若未設定則輸入框會顯示如 `/path/to/images` 的提示文字。
+
 ## 致謝
 
 本專案基於以下函式庫：

--- a/gradio_app.py
+++ b/gradio_app.py
@@ -1,0 +1,32 @@
+import os
+from dotenv import load_dotenv
+import gradio as gr
+import main
+
+load_dotenv()
+
+def run_pipeline(directory, output_directory):
+    if directory:
+        os.environ["directory"] = directory
+    if output_directory:
+        os.environ["output_directory"] = output_directory
+    code = main.main()
+    return "處理完成" if code == 0 else f"處理失敗，錯誤碼 {code}"
+
+# 從環境變數讀取預設值
+DEFAULT_DIR = os.getenv("directory", "")
+DEFAULT_OUT = os.getenv("output_directory", "")
+
+with gr.Blocks() as demo:
+    gr.Markdown("# Waifuc 圖像處理工具箱")
+    dir_box = gr.Textbox(label="圖片來源資料夾", value=DEFAULT_DIR,
+                         placeholder="/path/to/images")
+    out_box = gr.Textbox(label="輸出資料夾", value=DEFAULT_OUT,
+                         placeholder="/path/to/output")
+    run_btn = gr.Button("開始處理")
+    status = gr.Textbox(label="狀態輸出", interactive=False)
+
+    run_btn.click(run_pipeline, inputs=[dir_box, out_box], outputs=status)
+
+if __name__ == "__main__":
+    demo.launch()


### PR DESCRIPTION
## Summary
- add simple `gradio_app.py` with placeholder text
- prefill values from environment variables
- document Gradio defaults in README

## Testing
- `python -m py_compile gradio_app.py`
- `python -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_68464e0cdb048321a0e84cbcb90e3e09